### PR TITLE
set projectId in app.json, fixes eas project id #2 warning

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,6 +69,11 @@
     ],
     "experiments": {
       "tsconfigPaths": true
+    },
+    "extra": {
+      "eas": {
+        "projectId": "a95f3991-16ef-4f1c-88ab-82319447ad3e"
+      }
     }
   },
   "ignite": {


### PR DESCRIPTION
Currently, if I run `eas build`, or, for example,
```
eas build --profile development-simulator --platform ios
```

I get a warning and an error:
```
Warning: Your project uses dynamic app configuration, and the EAS project ID can't automatically be added to it.
https://docs.expo.dev/workflow/configuration/#dynamic-configuration-with-appconfigjs

To complete the setup process, set "extra.eas.projectId" in your app.config.ts or app.json:

{
  "expo": {
    "extra": {
      "eas": {
        "projectId": "a95f3991-16ef-4f1c-88ab-82319447ad3e"
      }
    }
  }
}

✖ Linking local project to EAS project a95f3991-16ef-4f1c-88ab-82319447ad3e
Cannot automatically write to dynamic config at: app.config.ts
    Error: build command failed.
```
<img width="1313" alt="image" src="https://github.com/softwarebyze/MarqueeApp/assets/77241170/7d707c12-748e-43e5-97cc-37fc7c7f7832">

I think this PR should fix it.